### PR TITLE
 Update CMakeLists.txt

### DIFF
--- a/libOTe/CMakeLists.txt
+++ b/libOTe/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB_RECURSE SRCS *.cpp)
 #include_directories(${CMAKE_SOURCE_DIR})
 add_library(libOTe STATIC ${SRCS})
 
-target_include_directories(libOTe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}) 
+target_include_directories(libOTe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/..) 
 target_link_libraries(libOTe cryptoTools)
 
 

--- a/libOTe/CMakeLists.txt
+++ b/libOTe/CMakeLists.txt
@@ -6,7 +6,7 @@ file(GLOB_RECURSE SRCS *.cpp)
 #include_directories(${CMAKE_SOURCE_DIR})
 add_library(libOTe STATIC ${SRCS})
 
-target_include_directories(libOTe PUBLIC ${CMAKE_SOURCE_DIR}) 
+target_include_directories(libOTe PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}) 
 target_link_libraries(libOTe cryptoTools)
 
 


### PR DESCRIPTION
libOTe will not compile with `target_include_directories(libOTe PUBLIC ${CMAKE_SOURCE_DIR})` if used as a library with a different root directory