### PR TITLE
fix duplicate variables

### DIFF
--- a/libOTe/Base/naor-pinkas.cpp
+++ b/libOTe/Base/naor-pinkas.cpp
@@ -71,8 +71,6 @@ namespace osuCrypto
 
         std::array<u8, RandomOracle::HashSize> comm, comm2;
         socket.asyncRecv(comm);
-        block R;
-        auto RFuture = socket.asyncRecv(R).share();
 
         for (u64 t = 0; t < numThreads; ++t)
         {


### PR DESCRIPTION
I believe the lines I deleted were duplicated above. See [here](https://github.com/osu-crypto/libOTe/blob/master/libOTe/Base/naor-pinkas.cpp#L69). 

I'm not sure if the order of the deletion matters, but I suspect it does not based on static analysis. 

This PR removes the duplicate lines and hence enables compilation to succeed when building with `cmake . -DENABLE_MIRACL=ON`

Please let me know if I need to adhere to a style guide or anything. Thanks!