### PR TITLE
Added missing return to NcoOtExtReceiver::genBaseOts

### DIFF
--- a/libOTe/NChooseOne/NcoOtExt.cpp
+++ b/libOTe/NChooseOne/NcoOtExt.cpp
@@ -20,6 +20,7 @@ void osuCrypto::NcoOtExtReceiver::genBaseOts(PRNG & prng, Channel & chl)
         sender.genBaseOts(prng, chl);
         sender.send(msgs, prng, chl);
         setBaseOts(msgs, prng, chl);
+        return;
 }
 #endif
 


### PR DESCRIPTION
The genBaseOts method of the NcoOtExtReceiver did not work in the passive-case when IKNP is enabled because a return statement was missing. Without it, both IKNP and KOS are executed instead of just one of them.