### PR TITLE
Fix #38

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,10 +165,9 @@ if(ENABLE_SSE)
 endif()
 
 
-configure_file(libOTe/config.h.in libOTe/config.h)
-
+configure_file(libOTe/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
 # Support out-of-source builds.
-include_directories(${CMAKE_BINARY_DIR})
+# include_directories(${CMAKE_BINARY_DIR})
 
 
 #############################################


### PR DESCRIPTION
Instead of include the binary directory, it would be better if we override the file `config.h` in the source folder (as this folder has been included by some files, I guess). 
CryptoTools actually wrote in this way; see https://github.com/ladnir/cryptoTools/blob/master/CMakeLists.txt.