### PR TITLE
add cmath to remove compilation error

### DIFF
--- a/libOTe/Tools/QuasiCyclicCode.h
+++ b/libOTe/Tools/QuasiCyclicCode.h
@@ -20,6 +20,7 @@
 #include "Tools.h"
 #include "LDPC/Mtx.h"
 #include "libOTe/TwoChooseOne/TcoOtDefines.h"
+#include <cmath>
 
 namespace osuCrypto
 {


### PR DESCRIPTION
Including cmath in the file removes the compilation error. 