### PR TITLE
Await socket flush

### DIFF
--- a/frontend/ExampleSilent.h
+++ b/frontend/ExampleSilent.h
@@ -37,7 +37,7 @@ namespace osuCrypto
         std::vector<SilentBaseType> types;
         if (cmd.isSet("base"))
             types.push_back(SilentBaseType::Base);
-        else 
+        else
             types.push_back(SilentBaseType::BaseExtend);
 
         macoro::thread_pool threadPool;
@@ -79,7 +79,7 @@ namespace osuCrypto
                     else
                     {
                         // optional. You can request that the base ot are generated either
-                        // using just base OTs (few rounds, more computation) or 128 base OTs and then extend those. 
+                        // using just base OTs (few rounds, more computation) or 128 base OTs and then extend those.
                         // The default is the latter, base + extension.
                         cp::sync_wait(sender.genSilentBaseOts(prng, chl, type == SilentBaseType::BaseExtend));
                     }
@@ -128,7 +128,7 @@ namespace osuCrypto
                     else
                     {
                         // optional. You can request that the base ot are generated either
-                        // using just base OTs (few rounds, more computation) or 128 base OTs and then extend those. 
+                        // using just base OTs (few rounds, more computation) or 128 base OTs and then extend those.
                         // The default is the latter, base + extension.
                         cp::sync_wait(recver.genSilentBaseOts(prng, chl, type == SilentBaseType::BaseExtend));
                     }
@@ -180,6 +180,8 @@ namespace osuCrypto
             }
 
         }
+
+        cp::sync_wait(chl.flushed());
 
 #endif
     }

--- a/frontend/ExampleVole.h
+++ b/frontend/ExampleVole.h
@@ -33,7 +33,7 @@ namespace osuCrypto
 		gTimer.setTimePoint("begin");
 		if (role == Role::Receiver)
 		{
-			// construct a vector to stored the received messages. 
+			// construct a vector to stored the received messages.
 			std::unique_ptr<block[]> backing0(new block[numOTs]);
 			std::unique_ptr<block[]> backing1(new block[numOTs]);
 			span<block> choice(backing0.get(), numOTs);
@@ -135,6 +135,7 @@ namespace osuCrypto
 
 		}
 
+		cp::sync_wait(chl.flushed());
 #endif
 	}
 


### PR DESCRIPTION
Wait for socket requests to complete before terminating socket. I was having trouble with running SilentOT and Silver due to chl not being flushed correctly and returned error code 139

Added this line to ExampleSilent.h and ExampleVOLE.h when silentVOLE or silentOT finishes
`cp::sync_wait(chl.flushed());`