### PR TITLE
Use the -f parameter in the SoftSpokenOT example

### DIFF
--- a/frontend/ExampleTwoChooseOne.cpp
+++ b/frontend/ExampleTwoChooseOne.cpp
@@ -32,34 +32,29 @@ namespace osuCrypto
 #ifdef ENABLE_SOFTSPOKEN_OT
     // soft spoken takes an extra parameter as input what determines
     // the computation/communication trade-off.
-    template<typename T>
+    template <typename T>
     using is_SoftSpoken = typename std::conditional<
-        //std::is_same<T, SoftSpokenShOtSender>::value ||
-        //std::is_same<T, SoftSpokenShOtReceiver>::value ||
-        //std::is_same<T, SoftSpokenShOtSender>::value ||
-        //std::is_same<T, SoftSpokenShOtReceiver>::value ||
-        //std::is_same<T, SoftSpokenMalOtSender>::value ||
-        //std::is_same<T, SoftSpokenMalOtReceiver>::value ||
-        //std::is_same<T, SoftSpokenMalOtSender>::value ||
-        //std::is_same<T, SoftSpokenMalOtReceiver>::value
-        false
-        ,
-        std::true_type, std::false_type>::type;
+        std::is_same<T, SoftSpokenShOtSender<>>::value ||
+            std::is_same<T, SoftSpokenShOtReceiver<>>::value ||
+            std::is_same<T, SoftSpokenMalOtSender>::value ||
+            std::is_same<T, SoftSpokenMalOtReceiver>::value,
+        std::true_type,
+        std::false_type>::type;
 #else
-    template<typename T>
+    template <typename T>
     using is_SoftSpoken = std::false_type;
 #endif
 
     template<typename T>
     typename std::enable_if<is_SoftSpoken<T>::value, T>::type
-        construct(CLP& cmd)
+        construct(const CLP& cmd)
     {
         return T(cmd.getOr("f", 2));
     }
 
     template<typename T>
     typename std::enable_if<!is_SoftSpoken<T>::value, T>::type
-        construct(CLP& cmd)
+        construct(const CLP& cmd)
     {
         return T{};
     }
@@ -79,10 +74,8 @@ namespace osuCrypto
 
         PRNG prng(sysRandomSeed());
 
-
-        OtExtSender  sender;
-        OtExtRecver  receiver;
-
+        OtExtSender sender = construct<OtExtSender>(cmd);
+        OtExtRecver receiver = construct<OtExtRecver>(cmd);
 
 #ifdef LIBOTE_HAS_BASE_OT
         // Now compute the base OTs, we need to set them on the first pair of extenders.

--- a/libOTe/TwoChooseOne/SoftSpokenOT/SoftSpokenMalOtExt.h
+++ b/libOTe/TwoChooseOne/SoftSpokenOT/SoftSpokenMalOtExt.h
@@ -153,6 +153,12 @@ namespace osuCrypto
 		SoftSpokenMalOtSender() {
 			init();
 		}
+
+		SoftSpokenMalOtSender(u64 fieldBits)
+		{
+			init(fieldBits);
+		}
+		
 		SoftSpokenMalOtSender(SoftSpokenMalOtSender&& o) = default;
 		SoftSpokenMalOtSender& operator=(SoftSpokenMalOtSender&& o) = default;
 
@@ -285,6 +291,13 @@ namespace osuCrypto
 		{
 			init();
 		}
+
+		SoftSpokenMalOtReceiver(u64 fieldBits)
+		{
+			init(fieldBits);
+		}
+
+
 		SoftSpokenMalOtReceiver(SoftSpokenMalOtReceiver&& o) 
 			:mBase(std::move(o.mBase))
 			,mExtraV(std::move(o.mExtraV))

--- a/libOTe/TwoChooseOne/SoftSpokenOT/SoftSpokenShOtExt.h
+++ b/libOTe/TwoChooseOne/SoftSpokenOT/SoftSpokenShOtExt.h
@@ -101,6 +101,11 @@ namespace osuCrypto
 				init();
 			}
 
+			SoftSpokenShOtSender(u64 fieldBits)
+			{
+				init(fieldBits);
+			}
+
 			SoftSpokenShOtSender(SoftSpokenShOtSender&& o)
 				: mSubVole(std::move(o.mSubVole))
 				, mBlockIdx(std::exchange(o.mBlockIdx, 0))
@@ -281,6 +286,12 @@ namespace osuCrypto
 			{
 				init();
 			}
+
+			SoftSpokenShOtReceiver(u64 fieldBits)
+			{
+				init(fieldBits);
+			}
+			
 			SoftSpokenShOtReceiver(const SoftSpokenShOtReceiver&) = delete;
 			SoftSpokenShOtReceiver(SoftSpokenShOtReceiver&& o) 
 				: mSubVole(std::move(o.mSubVole))


### PR DESCRIPTION
Currently, the SoftSpoken OT example when executed via the frontend doesn't make use of the "-f" parameter (fieldBits). This was due to the example code not differentiating between SoftSpokenOT type (which has the extra "-f" parameter) and other OT types. Fixing this required adding new constructors to the SoftSpokenOT Sender and Receiver classes.  