### PR TITLE
Also align `temp` for chosen-message OT

### DIFF
--- a/cmake/buildOptions.cmake
+++ b/cmake/buildOptions.cmake
@@ -57,8 +57,8 @@ if(DEFINED ENABLE_ALL_OT)
 	else()
 		set(oc_BB OFF)
 	endif()
-	set(ENABLE_SIMPLESTOT_ASM ${oc_BB}						CACHE BOOL "" FORCE)
-	set(ENABLE_MR_KYBER       ${oc_BB}						CACHE BOOL "" FORCE)
+	# set(ENABLE_SIMPLESTOT_ASM ${oc_BB}						CACHE BOOL "" FORCE)
+	# set(ENABLE_MR_KYBER       ${oc_BB}						CACHE BOOL "" FORCE)
 
 	# requires sse
 	if(ENABLE_SSE)

--- a/cmake/buildOptions.cmake
+++ b/cmake/buildOptions.cmake
@@ -57,8 +57,8 @@ if(DEFINED ENABLE_ALL_OT)
 	else()
 		set(oc_BB OFF)
 	endif()
-	# set(ENABLE_SIMPLESTOT_ASM ${oc_BB}						CACHE BOOL "" FORCE)
-	# set(ENABLE_MR_KYBER       ${oc_BB}						CACHE BOOL "" FORCE)
+	set(ENABLE_SIMPLESTOT_ASM ${oc_BB}						CACHE BOOL "" FORCE)
+	set(ENABLE_MR_KYBER       ${oc_BB}						CACHE BOOL "" FORCE)
 
 	# requires sse
 	if(ENABLE_SSE)

--- a/libOTe/TwoChooseOne/OTExtInterface.cpp
+++ b/libOTe/TwoChooseOne/OTExtInterface.cpp
@@ -122,7 +122,7 @@ namespace osuCrypto
 
 	{
 		MACORO_TRY{
-		auto temp = std::vector<std::array<block, 2>>(messages.size());
+		auto temp = AlignedUnVector<std::array<block, 2>>(messages.size());
 
 		co_await(send(temp, prng, chl));
 


### PR DESCRIPTION
Chosen message OT was still hitting the `messages must point to 32 byte aligned memory` that was just added, because the actual (temporary) input variable was not aligned. With this minor change, `frontend_libOTe -sshonest -chosen` runs correctly.